### PR TITLE
Optimize pipeline: parallel writers, DOCX on approval, configurable iterations

### DIFF
--- a/.claude/commands/agents/company-research.md
+++ b/.claude/commands/agents/company-research.md
@@ -10,22 +10,25 @@ Research a company and role context to inform job application narrative strategy
 ## Context
 You will receive the company name, role title, and a brief summary of the user's professional background (industries, technical domains, leadership experience) from their master reference.
 
+## Scope and Time Constraints
+
+Keep research focused and efficient. This agent should complete quickly; do not exhaustively research every aspect of the company.
+
+- **Limit web searches to 3 queries max.** Prioritize: (1) company overview + recent news, (2) role-specific context, (3) one connection-finding search tied to the user's background.
+- **Do not deep-dive** into company financials, full leadership bios, exhaustive product catalogs, or historical company timelines.
+- **Stop researching** once you have enough to write the output sections below. Good enough beats thorough here.
+
 ## Instructions
 
-1. Research the company using web search. Look for:
-   - Recent news, leadership changes, strategic priorities
-   - Technology stack and product direction (especially relevant for technical roles)
-   - Company culture, values, and mission
+1. Research the company using web search (3 searches max). Focus on:
+   - Company size, stage, key products, and market position
+   - 1-2 recent developments (news, strategy shifts, leadership changes)
    - Why this role might exist now (growth, replacement, new initiative)
-   - Company size, funding stage, and market position
-2. Research the specific role context:
+2. Briefly assess the role context:
    - What team or org does this role likely sit in?
    - What challenges is this function likely facing?
-3. Identify any meaningful connections to the user's background:
-   - Industry overlaps (look for matches between the user's experience and the company's domain)
-   - Technology stack matches (shared tools, platforms, or architectural patterns)
-   - Leadership experience parallels (team size, org complexity, transformation scope)
-   - Domain expertise alignment
+3. Identify 2-3 meaningful connections to the user's background:
+   - Industry overlaps, technology stack matches, leadership parallels, or domain alignment
 4. Flag anything that should influence the application narrative
 
 ## Output

--- a/.claude/commands/agents/cover-letter-writer.md
+++ b/.claude/commands/agents/cover-letter-writer.md
@@ -1,35 +1,40 @@
 # Cover Letter Writer Agent
 
 ## Your Role
-Write a compelling, tailored cover letter through five progressive iterations, each genuinely improving on the last.
+Write a compelling, tailored cover letter through progressive iterations, each genuinely improving on the last.
 
 ## Standing Preferences (from config)
 The orchestrator will pass the user's standing preferences, banned phrases, and preferred phrases from `config.md`. Apply ALL of these to every iteration. These are non-negotiable rules set by the user.
 
-Additionally, this rule always applies:
+Additionally, these rules always apply:
 - **Never use names of company employees** (hiring managers, executives, CIOs, etc.) in cover letters. Reference roles or titles if needed, but not individual names.
+- **Never attribute an accomplishment, metric, or capability to an employer unless it explicitly appears under that employer in the master reference.** When the narrative strategy asks you to reframe experience, reframe the language, not the facts. Do not move stories between employers or blend metrics from different roles. When in doubt, check which employer section a story comes from before including it.
 
 ## Identity Framing (from config)
 The orchestrator will pass the user's identity framing from `config.md`. This framing should anchor the cover letter summary.
 
+## Voice Brief (from orchestrator)
+The orchestrator will pass a **voice brief** as part of the narrative strategy. This brief defines the tone, register, and storytelling approach for this application. Follow it precisely to ensure voice consistency across all documents for this application.
+
 ## Context
 You will receive the following below:
 - Full master reference document (the user's career background, STAR projects, metrics, proven framings)
-- Focus guide / narrative strategy (centerpiece story, which STAR projects to prioritize, framings to use)
+- Focus guide / narrative strategy (centerpiece story, which STAR projects to prioritize, framings to use, **voice brief**)
 - New assets from the experience discovery interview
 - ATS keywords to weave in naturally
 - Company research summary
 - Full job description
 - The user's personal info (name) from config
 - The user's standing preferences, banned/preferred phrases from config
+- **Writing iterations count** from config (default: 3)
 
 ## Instructions
 
 ### Read the master reference first
 Read the master reference file at the path provided. This is your primary source of truth for the user's background, achievements, and proven framings.
 
-### Write 5 Iterations
-Each iteration should genuinely improve on the last: tighter language, stronger evidence, better flow.
+### Write N Iterations (from config)
+The orchestrator will tell you how many iterations to write (default: 3). Each iteration should genuinely improve on the last: tighter language, stronger evidence, better flow.
 
 **Structure for each iteration:**
 - Paragraph 1: The hook, the most compelling reason the user is a credible candidate for this specific role
@@ -38,6 +43,7 @@ Each iteration should genuinely improve on the last: tighter language, stronger 
 - Paragraph 4: Close, confident, specific, forward-looking
 
 **Key principles:**
+- Follow the voice brief for tone, register, and storytelling approach
 - Lead with the centerpiece story from the narrative strategy
 - Weave ATS keywords naturally; never keyword-stuff
 - Use specific metrics and outcomes from the master reference and new assets
@@ -46,11 +52,12 @@ Each iteration should genuinely improve on the last: tighter language, stronger 
 - The cover letter should feel like it could only have been written by this person for this specific role
 
 ### Critical Review
-After the fifth iteration, do an explicit critical review noting:
+After the final iteration, do an explicit critical review noting:
 - What works well
 - What changed between iterations
 - ATS keyword coverage check
 - Standing preferences compliance check
+- Voice brief adherence check
 
 ## Output
-Save the final (5th iteration) cover letter as `cover-letter.md` in the application folder path provided. The file should contain only the cover letter text, ready to use.
+Save the final iteration cover letter as `cover-letter.md` in the application folder path provided. The file should contain only the cover letter text, ready to use.

--- a/.claude/commands/agents/resume-writer.md
+++ b/.claude/commands/agents/resume-writer.md
@@ -1,13 +1,14 @@
 # Resume Writer Agent
 
 ## Your Role
-Tailor the user's resume to a specific role through five progressive iterations, each genuinely improving on the last.
+Tailor the user's resume to a specific role through progressive iterations, each genuinely improving on the last.
 
 ## Standing Preferences (from config)
 The orchestrator will pass the user's standing preferences, banned phrases, preferred phrases, and employer consolidation rules from `config.md`. Apply ALL of these to every iteration. These are non-negotiable rules set by the user.
 
 Additionally, these structural rules always apply:
 - **Never use names of company employees** (hiring managers, executives, CIOs, etc.) in resumes. Reference roles or titles if needed, but not individual names.
+- **Never attribute an accomplishment, metric, or capability to an employer unless it explicitly appears under that employer in the master reference.** When the narrative strategy asks you to reframe experience, reframe the language, not the facts. Do not move stories between employers or blend metrics from different roles. When in doubt, check which employer section a story comes from before including it.
 - **Skills/Core Competencies always go at the bottom of the resume**, after Education and Certifications. Never place them near the top.
 - **Resume must not exceed 2 pages.** Prioritize the most recent 10 years. Earlier roles get 1-2 bullets max.
 - **Contact info must include city and state.** Use clean LinkedIn format (no https://www. prefix).
@@ -18,24 +19,28 @@ Additionally, these structural rules always apply:
 ## Identity Framing (from config)
 The orchestrator will pass the user's identity framing from `config.md`. This framing should anchor the resume summary/headline.
 
+## Voice Brief (from orchestrator)
+The orchestrator will pass a **voice brief** as part of the narrative strategy. This brief defines the tone, register, and storytelling approach for this application. Follow it precisely to ensure voice consistency across all documents for this application.
+
 ## Context
 You will receive the following below:
 - Full master reference document (the user's career background, STAR projects, metrics, proven framings)
-- Focus guide / narrative strategy (centerpiece story, which STAR projects to prioritize, framings to use)
+- Focus guide / narrative strategy (centerpiece story, which STAR projects to prioritize, framings to use, **voice brief**)
 - New assets from the experience discovery interview
 - ATS keywords to weave in naturally
 - Company research summary
 - Full job description
 - The user's personal info (name, phone, email, LinkedIn, location) from config
 - The user's standing preferences, banned/preferred phrases, employer consolidation rules from config
+- **Writing iterations count** from config (default: 3)
 
 ## Instructions
 
 ### Read the master reference first
 Read the master reference file at the path provided. This is your primary source of truth for the user's background, achievements, and proven framings.
 
-### Write 5 Iterations
-Each iteration should genuinely improve on the last. The resume for each role is a unique document; do not copy structure blindly from past resumes.
+### Write N Iterations (from config)
+The orchestrator will tell you how many iterations to write (default: 3). Each iteration should genuinely improve on the last. The resume for each role is a unique document; do not copy structure blindly from past resumes.
 
 **Key questions for each pass:**
 - Does the summary match what this specific employer is hiring for?
@@ -60,7 +65,7 @@ Each iteration should genuinely improve on the last. The resume for each role is
 - Skills / Core Competencies (BOTTOM, 15-20 specific technologies/platforms)
 
 ### Critical Review
-After the fifth iteration, do an explicit critical review noting:
+After the final iteration, do an explicit critical review noting:
 - What works well
 - What changed between iterations
 - ATS keyword coverage check
@@ -70,10 +75,11 @@ After the fifth iteration, do an explicit critical review noting:
 - Headline check: does it mirror the target role title?
 - Skills count check: are there 15-20 specific technologies listed?
 - Contact info check: city/state present, clean LinkedIn URL?
+- Voice brief adherence check
 
 ## Output
 
-Save the final (5th iteration) resume as `resume.md` in the application folder path provided. The file should contain only the resume text, ready to use.
+Save the final iteration resume as `resume.md` in the application folder path provided. The file should contain only the resume text, ready to use.
 
 ### DOCX-Aware Formatting Conventions
 

--- a/.claude/commands/job-search.md
+++ b/.claude/commands/job-search.md
@@ -89,7 +89,11 @@ When passing context to writing agents, always include:
 
 When the user provides a new job description (or a URL to one), follow these phases in order.
 
-### URL Detection
+### Phase 2: Folder Creation + JD Capture
+
+**This is always the first action after receiving a JD.** Before any analysis or interaction.
+
+#### URL Detection
 
 If the user provides a URL instead of (or along with) job description text:
 
@@ -99,7 +103,24 @@ If the user provides a URL instead of (or along with) job description text:
 4. If the user confirms, use the extracted text as the job description for all subsequent phases
 5. If scraping fails (network error, login-walled page, no readable content), ask the user to paste the JD text manually
 
-### Phase 2: Parallel Analysis
+#### Create the Application Folder
+
+Once you have the JD text (from paste or confirmed scrape), immediately:
+
+1. Create the application folder in the current working directory:
+   ```
+   YYYY-MM-DD_Company-Name_Job-Title/
+   ```
+   Rules:
+   - Use today's date
+   - Sanitize company name and job title: spaces become hyphens, remove special characters
+   - Example: `2026-03-26_Acme-Corp_Senior-Software-Engineer`
+
+2. Save the full job description text as `jd.txt` in the application folder. If a URL was provided, include it as the first line of the file followed by a blank line, then the full JD text.
+
+This folder is now the working directory for this application. All subsequent outputs go here.
+
+### Phase 3: Parallel Analysis
 
 Spawn two agents **simultaneously** using the Agent tool:
 
@@ -117,7 +138,7 @@ Spawn two agents **simultaneously** using the Agent tool:
 
 Launch both agents in a single response using two Agent tool calls. Wait for both to return before proceeding.
 
-### Phase 3: Interactive Discovery (in main conversation)
+### Phase 4: Interactive Discovery (in main conversation)
 
 With both agent results in hand:
 
@@ -138,80 +159,90 @@ Wait for the user's answers before proceeding. These two questions are all that'
 - Which new assets from the interview should be front and center?
 - What proven narrative framings from the master reference apply?
 
-Present the narrative strategy and get the user's input before writing. This narrative strategy becomes the **focus guide** passed to writing agents.
+**Voice Brief**: As part of the narrative strategy, define a **voice brief** that both writing agents will follow. The voice brief specifies:
+- **Tone**: e.g., confident and warm, technically authoritative, mission-driven
+- **Register**: e.g., executive peer-to-peer, senior IC to hiring manager, leader-to-leader
+- **Storytelling approach**: e.g., lead with transformation narrative, lead with technical depth, lead with scale/impact
+- **Key phrases/language**: specific terms or phrasings that should thread through both documents for consistency
 
-### Phase 4: Folder Creation
+Present the narrative strategy (including voice brief) and get the user's input before writing. This becomes the **focus guide** passed to both writing agents.
 
-Create the application folder in the current working directory:
+### Phase 5: Document Generation (Parallel)
 
-```
-YYYY-MM-DD_Company-Name_Job-Title/
-```
+Spawn both writing agents **simultaneously** using two Agent tool calls. The voice brief ensures consistent voice across both documents without requiring sequential execution.
 
-Rules:
-- Use today's date
-- Sanitize company name and job title: spaces become hyphens, remove special characters
-- Example: `2026-03-26_Acme-Corp_Senior-Software-Engineer`
-
-After creating the folder, save the full job description text as `jd.txt` in the application folder. This preserves the original JD for future reference.
-
-### Phase 5: Document Generation (Sequential)
-
-Spawn writing agents **sequentially** (cover letter first, then resume). The cover letter establishes narrative voice; the resume follows.
+Read the **Writing Iterations** count from `config.md` (default: 3). Pass this count to both agents.
 
 **Agent 3: Cover Letter Writer**
 - Read the prompt from `.claude/commands/agents/cover-letter-writer.md`
 - Pass to the agent:
   - Master reference file path (agent will Read it)
-  - The focus guide / narrative strategy from Step D
+  - The focus guide / narrative strategy from Step D (including voice brief)
   - New assets from the interview
   - ATS keywords from Step A
-  - Company research summary from Step C
+  - Company research summary
   - Full job description text
   - Application folder path for saving `cover-letter.md`
   - All config values: standing preferences, banned/preferred phrases, identity framing, personal info
+  - Writing iterations count from config
 - Agent returns: final cover letter saved to folder
 
-**Agent 4: Resume Writer** (after cover letter completes)
+**Agent 4: Resume Writer**
 - Read the prompt from `.claude/commands/agents/resume-writer.md`
 - Pass to the agent:
   - Master reference file path (agent will Read it)
-  - The focus guide / narrative strategy from Step D
+  - The focus guide / narrative strategy from Step D (including voice brief)
   - New assets from the interview
   - ATS keywords from Step A
-  - Company research summary from Step C
+  - Company research summary
   - Full job description text
   - Application folder path for saving `resume.md`
   - All config values: standing preferences, banned/preferred phrases, employer consolidation rules, identity framing, personal info
+  - Writing iterations count from config
 - Agent returns: final resume saved to folder
 
-**Agent 5: DOCX Producer** (after resume completes)
-- Read the prompt from `.claude/commands/agents/docx-producer.md`
-- Pass: file path to the saved `resume.md`, application folder path, company name and role title, user's name from config, DOCX styling values from config
-- Agent produces ATS-optimized resume DOCX in the application folder
-- Report the DOCX file path in Phase 7 review
+Launch both agents in a single response. Wait for both to return before proceeding.
 
-**Agent 6: ATS Review** (after DOCX producer completes)
+### Phase 6: Post-Writing (Parallel)
+
+After both documents are complete, spawn these agents **simultaneously**:
+
+**Agent 5: ATS Review**
 - Read the prompt from `.claude/commands/agents/ats-review.md`
-- Pass: resume file path, full job description text, ATS keyword analysis from Step A, and screening questions if available
-- Agent returns: parse simulation, red flags, keyword coverage score, screening question check, and top 3 recommended changes
-- Present results in Phase 7 review. If critical red flags or low keyword coverage, flag for the user's attention before finalizing.
+- Pass: resume file path, full job description text, ATS keyword analysis from Phase 3, and screening questions if available
+- Agent returns: parse simulation, red flags, keyword coverage score, and top 3 recommended changes
 
-### Phase 6: Master Reference Update
-
-After both documents are complete, spawn the master reference updater agent:
-
+**Agent 6: Master Reference Update**
 - Read the prompt from `.claude/commands/agents/master-reference-updater.md`
 - Pass: master reference file path (from config), new assets, new framings, application tracker row data (date, company, role, status, folder path)
 
-### Phase 7: Review with User
+Launch both agents in a single response.
+
+### Phase 7: Review and Approval
 
 Present a summary of what was created:
 - Cover letter highlights (centerpiece story, key evidence used)
 - Resume highlights (summary framing, leading bullets)
-- DOCX resume file path (ready for ATS upload)
+- ATS review results: keyword coverage score and any red flags or recommended changes
 - What was added to the master reference
-- Offer to generate cover letter DOCX if needed
+
+If the ATS review flagged critical issues (red flags or low keyword coverage), highlight them and offer to revise the resume before proceeding.
+
+**Ask for approval**: "Review the cover letter and resume in the application folder. Let me know if you'd like any changes, or say 'approved' to generate the final DOCX files."
+
+### Phase 8: DOCX Production (on approval only)
+
+**DOCX files are only generated after the user explicitly approves the markdown documents.** Do not generate DOCX at any earlier stage.
+
+Once the user approves:
+
+Spawn the DOCX producer agent to generate **both** resume and cover letter DOCX files:
+
+- Read the prompt from `.claude/commands/agents/docx-producer.md`
+- **Resume DOCX**: Pass file path to `resume.md`, application folder path, company name and role title, user's name from config, DOCX styling values from config
+- **Cover Letter DOCX**: Pass file path to `cover-letter.md`, application folder path, company name and role title, user's name from config, DOCX styling values from config
+
+Report both DOCX file paths to the user. These are the final ATS-ready deliverables.
 
 ---
 
@@ -219,11 +250,11 @@ Present a summary of what was created:
 
 These are triggered by specific requests, not part of the standard workflow.
 
-### Cover Letter DOCX Production
+### DOCX Production
 
-Resume DOCX is generated automatically in Phase 5. When the user requests a cover letter DOCX:
+When the user requests DOCX generation for any document outside the standard workflow:
 - Read the prompt from `.claude/commands/agents/docx-producer.md`
-- Pass: file path to cover-letter.md, application folder path, company name and role title, user's name from config, DOCX styling from config
+- Pass: file path to the markdown source, application folder path, company name and role title, user's name from config, DOCX styling from config
 
 ### Compensation Research
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The `/job-search` skill uses an orchestrator + sub-agent pattern:
 
 **Why sub-agents?** Writing agents (cover letter, resume) receive only the context they need (master reference + focus guide + JD + keywords) instead of the full conversation history. This eliminates ~15-30KB of conversation noise and improves writing quality.
 
-**Parallelism:** ATS keyword analysis and company research run in parallel. Cover letter then resume run sequentially (cover letter establishes narrative voice).
+**Parallelism:** Three parallel stages: (1) ATS keyword analysis + company research, (2) cover letter + resume writing (voice brief ensures consistency), (3) ATS review + master reference update. DOCX is only generated after user approves the markdown drafts.
 
 ## Configuration
 
@@ -25,4 +25,4 @@ Each application gets its own folder in this directory:
 ```
 YYYY-MM-DD_Company-Name_Job-Title/
 ```
-Contains `resume.md` and `cover-letter.md` by default. DOCX generated automatically for resumes.
+Contains `jd.txt`, `resume.md`, and `cover-letter.md`. DOCX files generated only after user approval.

--- a/config.example.md
+++ b/config.example.md
@@ -61,6 +61,12 @@ A customer-focused technology leader who builds scalable platforms and leads hig
 <!-- Example: -->
 <!-- - **Acme Corp**: Consolidate as one entry with titles: Engineer, Senior Engineer, Staff Engineer (Jan 2018 - Dec 2023) -->
 
+## Writing Agent Settings
+
+- **Writing Iterations**: 3
+
+<!-- Number of progressive iterations each writing agent (cover letter, resume) performs. Default is 3. Higher values produce more polished output but take longer. Range: 2-5. -->
+
 ## DOCX Styling
 
 - **Accent Color**: #1B3A5C


### PR DESCRIPTION
## Summary
- **Folder creation moved to first step** after JD is received, before any analysis
- **Cover letter + resume now write in parallel** using a shared voice brief for tone consistency (previously sequential)
- **ATS review + master reference update now run in parallel** (previously sequential)
- **DOCX generation gated behind user approval** (new Phase 8) instead of auto-generating during writing
- **Writing iterations configurable** via `config.md` (default reduced from 5 to 3)
- **Company research capped at 3 web searches** to reduce research time
- **Factual accuracy guardrail** added to both writer agents: prevents attributing accomplishments to the wrong employer when reframing narratives

## Files Changed
- `.claude/commands/job-search.md` — Orchestrator rewrite (phases renumbered, parallel stages, approval gate)
- `.claude/commands/agents/cover-letter-writer.md` — Configurable iterations, voice brief, factual accuracy rule
- `.claude/commands/agents/resume-writer.md` — Configurable iterations, voice brief, factual accuracy rule
- `.claude/commands/agents/company-research.md` — 3-search cap, scope constraints
- `config.example.md` — New `Writing Agent Settings` section
- `CLAUDE.md` — Updated architecture description

## Test plan
- [ ] Run `/job-search` with a new JD and verify folder + jd.txt are created before analysis starts
- [ ] Verify cover letter and resume agents launch in parallel
- [ ] Verify DOCX is NOT generated until user says "approved"
- [ ] Test with `Writing Iterations: 2` and `Writing Iterations: 5` in config
- [ ] Verify company research completes faster with 3-search cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)